### PR TITLE
[Feat] 카카오 로그인 api 연결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import BasketPage from './pages/BasketPage';
 import LoginPage from './pages/LoginPage';
 import SearchResultPage from './pages/SearchResultPage';
 import Layout from './components/Layout/Layout';
+import Redirection from './pages/Redirection';
 
 function App() {
   return (
@@ -17,10 +18,11 @@ function App() {
           <Route index element={<HomePage />} />
           <Route path="/branch/:branchName" element={<BranchPage />} />
           <Route path="/detail/:id" element={<DetailPage />} />
-          <Route paht="/search" element={<SearchResultPage />} />
+          <Route path="/search" element={<SearchResultPage />} />
           <Route path="/basket" element={<BasketPage />} />
         </Route>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/oauth2/callback" element={<Redirection />} />
         <Route path="*" element={<h1>Not Found</h1>} />
       </Routes>
     </Router>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,9 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 import LoginForm from '../components/LoginPage/LoginForm';
 import kakaoImg from '../../src/assets/images/Login/kakao-login.png';
 
 const LoginPage = () => {
+  const handleKakaoLogin = () => {
+    axios
+      .get(`https://api.toy-team1.o-r.kr/login`)
+      .then((response) => {
+        console.log('응답 데이터:', response.data); // 응답 데이터 출력
+        console.log('로그인 접속!');
+        window.location.href = response.data; // 백엔드에서 받은 URL로 리디렉션
+      })
+      .catch((error) => {
+        console.error('로그인 실패', error);
+      });
+  };
+
   return (
     <LoginComponent>
       <LoginBox>
@@ -12,7 +26,7 @@ const LoginPage = () => {
       </LoginBox>
       <KakaoLogin>
         <KakaoText>카카오 계정으로 로그인 하기</KakaoText>
-        <KakaoImg src={kakaoImg} alt="카카오 로그인" />
+        <KakaoImg src={kakaoImg} alt="카카오 로그인" onClick={handleKakaoLogin} />
       </KakaoLogin>
     </LoginComponent>
   );

--- a/src/pages/Redirection.jsx
+++ b/src/pages/Redirection.jsx
@@ -1,0 +1,37 @@
+import React, {useEffect} from 'react';
+import axios from 'axios';
+import {useNavigate} from 'react-router-dom';
+
+const Redirection = () => {
+  const code = new URL(window.location.href).searchParams.get('code');
+  const navigate = useNavigate();
+  console.log(code);
+
+  useEffect(() => {
+    if (code) {
+      axios
+        .get(`https://api.toy-team1.o-r.kr/oauth2/kakao?code=${code}`)
+        .then((response) => {
+          const {userinfo, accessToken, refreshToken} = response.data;
+          console.log(response.data);
+          console.log(userinfo);
+          window.localStorage.setItem('access_token', accessToken);
+          window.localStorage.setItem('refresh_token', refreshToken);
+          console.log('로그인 성공');
+          navigate('/');
+        })
+        .catch((error) => {
+          console.error(error);
+          console.log('로그인 실패');
+        });
+    }
+  }, [code, navigate]);
+
+  return (
+    <div>
+      <h1>Loading...</h1>
+    </div>
+  );
+};
+
+export default Redirection;


### PR DESCRIPTION
## 🚀 PR 요약
카카오 로그인 api 연결

## 🚀 PR 상세
- 카카오 로그인 버튼 클릭 시 서버에서 전달받은 카카오 로그인 주소로 연결
- 카카오 로그인 완료 후 인가코드 서버에 전달, 서버에서 토큰 발급
- 로그인 성공 시 홈페이지로 자동 리다이렉트

## 🚀 스크린샷
https://github.com/EFUB4-TOY-ALADIN/Efub4-Toy-Front-End/assets/140916799/e35a5df2-887e-4bd5-8c86-849d83217dc2

## 🚀 기타
- 이메일과 비밀번호 입력하는 로그인도 동일하게 작동합니다
- 개인 계정으로 로그인하시려면 따로 DB에 post로 회원정보 데이터를 넣어주어야 합니다(postman 이용)
